### PR TITLE
Use static mocking

### DIFF
--- a/SpecialLibrary.php
+++ b/SpecialLibrary.php
@@ -10,7 +10,7 @@ class SpecialLibrary
     public static function doublePrefix($inputString) {
         $outputString = $inputString;
         for ($i = 0; $i < 2; $i++) {
-            $outputString = self::prefix($outputString);
+            $outputString = static::prefix($outputString);
         }
         return $outputString;
     }

--- a/tests/SpecialLibraryTest.php
+++ b/tests/SpecialLibraryTest.php
@@ -30,9 +30,10 @@ final class SpecialLibraryTest extends \PHPUnit\Framework\TestCase
 
         $mockSpecialLibrary = Phony::mock(SpecialLibrary::class);
         $staticSpecialLibrary = Phony::onStatic($mockSpecialLibrary);
-        $staticSpecialLibrary->doublePrefix->returns($mockOutput);
-        
-        $testOutput = SpecialLibrary::doublePrefix($testInput);
+        $staticSpecialLibrary->prefix->returns($mockOutput);
+        $mockClass = $staticSpecialLibrary->className();
+
+        $testOutput = $mockClass::doublePrefix($testInput);
         $this->assertEquals($testOutput, $mockOutput);
 
     }


### PR DESCRIPTION
This PR demonstrates how you *could* use Phony's [static mocks](https://eloquent-software.com/phony/latest/#static-mocks) to achieve your original goal.

As I mentioned on Twitter, you can't actually re-define the `SpecialLibrary` class. Mocking in Phony always involves creating a sub-class. So in order to access the mocked static method, you would have to use a dynamic class name.

In addition, you would need to employ [late static binding](https://www.php.net/manual/en/language.oop5.late-static-bindings.php) via the use of `static::` in order for the mocked methods to be called by other methods in the same class.