### PR TITLE
Use global function fallback

### DIFF
--- a/SpecialLibrary.php
+++ b/SpecialLibrary.php
@@ -1,15 +1,19 @@
 <?php
 
-function prefix($inputString) {
-    return "prefix " . $inputString;
+namespace {
+    function prefix($inputString) {
+        return "prefix " . $inputString;
+    }
 }
 
-function doublePrefix($inputString) {
-    $outputString = $inputString;
-    for ($i = 0; $i < 2; $i++) {
-        $outputString = prefix($outputString);
+namespace Example {
+    function doublePrefix($inputString) {
+        $outputString = $inputString;
+        for ($i = 0; $i < 2; $i++) {
+            $outputString = prefix($outputString);
+        }
+        return $outputString;
     }
-    return $outputString;
 }
 
 ?>

--- a/tests/SpecialLibraryTest.php
+++ b/tests/SpecialLibraryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Example;
+
 use PHPUnit\Framework\TestCase;
 use Eloquent\Phony\Phpunit\Phony;
 
@@ -8,10 +10,22 @@ require_once("SpecialLibrary.php");
 final class SpecialLibraryTest extends \PHPUnit\Framework\TestCase
 {
 
+    protected function setUp(): void
+    {
+        $this->prefix = Phony::stubGlobal('prefix', __NAMESPACE__);
+    }
+
+    protected function tearDown(): void
+    {
+        Phony::restoreGlobalFunctions();
+    }
+
     public function testPrefix(): void
     {
         $testInput = "foo";
         $targetOutput = "prefix foo";
+
+        $this->prefix->forwards();
 
         $testOutput = prefix($testInput);
         $this->assertEquals($testOutput, $targetOutput);
@@ -22,7 +36,7 @@ final class SpecialLibraryTest extends \PHPUnit\Framework\TestCase
         $testInput = "foo";
         
         $stubOutput = "bar";
-        $stubPrefix = Phony::stub("prefix")->returns($stubOutput);
+        $this->prefix->returns($stubOutput);
 
         $testOutput = doublePrefix($testInput);
         $this->assertEquals($testOutput, $stubOutput);


### PR DESCRIPTION
This PR demonstrates how you *could* use Phony's [`stubGlobal`](https://eloquent-software.com/phony/latest/#stubbing-global-functions) to achieve your original goal.

This approach takes advantage of PHP's [global function fallback](https://php.net/language.namespaces.fallback) behaviour, so the function being called must be in the global namespace, and the code calling the function must *not* be in the global namespace.