### PR TITLE
Use an injected prefix function

### DIFF
--- a/SpecialLibrary.php
+++ b/SpecialLibrary.php
@@ -4,10 +4,10 @@ function prefix($inputString) {
     return "prefix " . $inputString;
 }
 
-function doublePrefix($inputString) {
+function doublePrefix($inputString, $prefixFn = 'prefix') {
     $outputString = $inputString;
     for ($i = 0; $i < 2; $i++) {
-        $outputString = prefix($outputString);
+        $outputString = $prefixFn($outputString);
     }
     return $outputString;
 }

--- a/tests/SpecialLibraryTest.php
+++ b/tests/SpecialLibraryTest.php
@@ -20,13 +20,42 @@ final class SpecialLibraryTest extends \PHPUnit\Framework\TestCase
     public function testDoublePrefix(): void
     {
         $testInput = "foo";
-        
-        $stubOutput = "bar";
-        $stubPrefix = Phony::stub("prefix")->returns($stubOutput);
 
-        $testOutput = doublePrefix($testInput);
-        $this->assertEquals($testOutput, $stubOutput);
+        // Stubbing the original function is only useful if you want to produce
+        // a stub that "forwards" (defers) to the original function in some
+        // specific cases.
 
+        // Since you're not doing this, an "anonymous" stub will suffice:
+
+        $stubPrefix = Phony::stub()->does(function ($inputString) {
+            return "bar " . $inputString;
+        });
+
+        $this->assertEquals("prefix prefix foo", doublePrefix($testInput));
+        $this->assertEquals("bar bar foo", doublePrefix($testInput, $stubPrefix));
+
+        // but unless you plan to verify interactions with $stubPrefix, like so:
+
+        $stubPrefix->calledWith("foo");
+        $stubPrefix->calledWith("bar foo");
+
+        // then of course, you don't need Phony at all:
+
+        $prefixWithBaz = function ($inputString) {
+            return "baz " . $inputString;
+        };
+
+        $this->assertEquals("baz baz foo", doublePrefix($testInput, $prefixWithBaz));
+
+        // In some cases, you might be more concerned with how prefix is used by
+        // doublePrefix, and don't actually want to change the behavior of
+        // prefix at all. In these cases, a spy is a better option:
+
+        $spyPrefix = Phony::spy('prefix');
+
+        $this->assertEquals("prefix prefix foo", doublePrefix($testInput, $spyPrefix));
+        $spyPrefix->calledWith("foo");
+        $spyPrefix->calledWith("prefix foo");
     }
 
 };


### PR DESCRIPTION
This PR demonstrates how you *could* use inversion of control / dependency injection to achieve your original goal.

Based on your original tweet, I'm guessing you want to create a library of functions, with some interaction between those functions. If I were doing the same, my approach would be:

**Ideal approach**: Test the entire library with functional tests, and don't use stubs at all (best approach, but can be tough)

OR

**Compromise approach**: Use dependency injection. For functions that depend on other functions, inject the dependency via an argument.

You may also want to consider "giving up" and writing a class that gets instantiated instead. Functions have long been second-class citizens in PHP. For one thing, they cannot be auto-loaded by Composer like classes can.

If you stick with the idea of functions, I would definitely suggest putting them in a namespace at least.